### PR TITLE
Instance Methods

### DIFF
--- a/core-lib/src/command/oso/builtins.rs
+++ b/core-lib/src/command/oso/builtins.rs
@@ -7,59 +7,59 @@ use super::{Class, ClassBuilder, PolarValue};
 fn boolean() -> ClassBuilder<bool> {
     ClassBuilder::<bool>::with_default()
         .with_equality_check()
-        .name("Boolean")
+        .name("bool")
 }
 
 fn integer() -> ClassBuilder<i64> {
     ClassBuilder::<i64>::with_default()
         .with_equality_check()
-        .name("Integer")
+        .name("int")
 }
 
 fn float() -> ClassBuilder<f64> {
     ClassBuilder::<f64>::with_default()
         .with_equality_check()
-        .name("Float")
+        .name("float")
 }
 
 fn list() -> ClassBuilder<Vec<PolarValue>> {
     ClassBuilder::<Vec<PolarValue>>::with_default()
         .with_equality_check()
-        .name("List")
+        .name("list")
 }
 
 fn dictionary() -> ClassBuilder<HashMap<String, PolarValue>> {
     ClassBuilder::<HashMap<String, PolarValue>>::with_default()
         .with_equality_check()
-        .name("Dictionary")
+        .name("dict")
 }
 
 fn option() -> ClassBuilder<Option<PolarValue>> {
     ClassBuilder::<Option<PolarValue>>::with_default()
         .with_equality_check()
-        .name("Option")
-        .add_method("unwrap", |v: &Option<PolarValue>| v.clone().unwrap())
-        .add_method("is_none", Option::is_none)
-        .add_method("is_some", Option::is_some)
+        .name("option")
+        .legacy_add_method("unwrap", |v: &Option<PolarValue>| v.clone().unwrap())
+        .legacy_add_method("is_none", Option::is_none)
+        .legacy_add_method("is_some", Option::is_some)
         .with_iter()
 }
 
 fn string() -> ClassBuilder<String> {
     ClassBuilder::<String>::with_default()
         .with_equality_check()
-        .name("String")
-        .add_method("len", |s: &String| s.len() as i64)
-        .add_method("is_empty", String::is_empty)
-        .add_method("is_char_boundary", |s: &String, index: i64| {
+        .name("string")
+        .legacy_add_method("len", |s: &String| s.len() as i64)
+        .legacy_add_method("is_empty", String::is_empty)
+        .legacy_add_method("is_char_boundary", |s: &String, index: i64| {
             s.is_char_boundary(index as usize)
         })
-        .add_method("bytes", |s: &String| {
+        .legacy_add_method("bytes", |s: &String| {
             s.bytes().map(|c| c as i64).collect::<Vec<i64>>()
         })
-        .add_method("chars", |s: &String| {
+        .legacy_add_method("chars", |s: &String| {
             s.chars().map(|c| c.to_string()).collect::<Vec<String>>()
         })
-        .add_method("char_indices", |s: &String| {
+        .legacy_add_method("char_indices", |s: &String| {
             s.char_indices()
                 .map(|(i, c)| {
                     vec![
@@ -69,67 +69,67 @@ fn string() -> ClassBuilder<String> {
                 })
                 .collect::<Vec<Vec<PolarValue>>>()
         })
-        .add_method("split_whitespace", |s: &String| {
+        .legacy_add_method("split_whitespace", |s: &String| {
             s.split_whitespace()
                 .map(|c| c.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("lines", |s: &String| {
+        .legacy_add_method("lines", |s: &String| {
             s.lines().map(|c| c.to_string()).collect::<Vec<String>>()
         })
-        .add_method("lines", |s: &String| {
+        .legacy_add_method("lines", |s: &String| {
             s.lines().map(|c| c.to_string()).collect::<Vec<String>>()
         })
-        .add_method("contains", |s: &String, pat: String| s.contains(&pat))
-        .add_method("starts_with", |s: &String, pat: String| s.starts_with(&pat))
-        .add_method("ends_with", |s: &String, pat: String| s.ends_with(&pat))
-        .add_method("find", |s: &String, pat: String| {
+        .legacy_add_method("contains", |s: &String, pat: String| s.contains(&pat))
+        .legacy_add_method("starts_with", |s: &String, pat: String| s.starts_with(&pat))
+        .legacy_add_method("ends_with", |s: &String, pat: String| s.ends_with(&pat))
+        .legacy_add_method("find", |s: &String, pat: String| {
             s.find(&pat).map(|i| i as i64)
         })
-        .add_method("rfind", |s: &String, pat: String| {
+        .legacy_add_method("rfind", |s: &String, pat: String| {
             s.rfind(&pat).map(|i| i as i64)
         })
-        .add_method("split", |s: &String, pat: String| {
+        .legacy_add_method("split", |s: &String, pat: String| {
             s.split(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("rsplit", |s: &String, pat: String| {
+        .legacy_add_method("rsplit", |s: &String, pat: String| {
             s.rsplit(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("split_terminator", |s: &String, pat: String| {
+        .legacy_add_method("split_terminator", |s: &String, pat: String| {
             s.split_terminator(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("rsplit_terminator", |s: &String, pat: String| {
+        .legacy_add_method("rsplit_terminator", |s: &String, pat: String| {
             s.rsplit_terminator(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("splitn", |s: &String, n: i32, pat: String| {
+        .legacy_add_method("splitn", |s: &String, n: i32, pat: String| {
             s.splitn(n as usize, &pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("rsplitn", |s: &String, n: i32, pat: String| {
+        .legacy_add_method("rsplitn", |s: &String, n: i32, pat: String| {
             s.rsplitn(n as usize, &pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("matches", |s: &String, pat: String| {
+        .legacy_add_method("matches", |s: &String, pat: String| {
             s.matches(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("rmatches", |s: &String, pat: String| {
+        .legacy_add_method("rmatches", |s: &String, pat: String| {
             s.rmatches(&pat)
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
         })
-        .add_method("match_indices", |s: &String, pat: String| {
+        .legacy_add_method("match_indices", |s: &String, pat: String| {
             s.match_indices(&pat)
                 .map(|(i, c)| {
                     vec![
@@ -139,7 +139,7 @@ fn string() -> ClassBuilder<String> {
                 })
                 .collect::<Vec<Vec<PolarValue>>>()
         })
-        .add_method("rmatch_indices", |s: &String, pat: String| {
+        .legacy_add_method("rmatch_indices", |s: &String, pat: String| {
             s.rmatch_indices(&pat)
                 .map(|(i, c)| {
                     vec![
@@ -149,13 +149,13 @@ fn string() -> ClassBuilder<String> {
                 })
                 .collect::<Vec<Vec<PolarValue>>>()
         })
-        .add_method("trim", |s: &String| s.trim().to_string())
-        .add_method("trim_start", |s: &String| s.trim_start().to_string())
-        .add_method("trim_end", |s: &String| s.trim_end().to_string())
-        .add_method("is_ascii", |s: &String| s.is_ascii())
-        .add_method("to_lowercase", |s: &String| s.to_lowercase())
-        .add_method("to_uppercase", |s: &String| s.to_uppercase())
-        .add_method("repeat", |s: &String, n: i64| s.repeat(n as usize))
+        .legacy_add_method("trim", |s: &String| s.trim().to_string())
+        .legacy_add_method("trim_start", |s: &String| s.trim_start().to_string())
+        .legacy_add_method("trim_end", |s: &String| s.trim_end().to_string())
+        .legacy_add_method("is_ascii", |s: &String| s.is_ascii())
+        .legacy_add_method("to_lowercase", |s: &String| s.to_lowercase())
+        .legacy_add_method("to_uppercase", |s: &String| s.to_uppercase())
+        .legacy_add_method("repeat", |s: &String, n: i64| s.repeat(n as usize))
 }
 
 /// Returns the builtin types, the name, class, and instance

--- a/core-lib/src/command/oso/class_method.rs
+++ b/core-lib/src/command/oso/class_method.rs
@@ -1,6 +1,6 @@
 //! Wrapper structs for the generic `Function` and `Method` traits
 use std::sync::Arc;
-use super::{PolarIterator, ToPolar, ToPolarResult, ParamType, Class, Instance, PolarValue,
+use super::{PolarIterator, ToPolar, ToPolarResult, Class, Instance, PolarValue,
             FromPolarList, Host};
 use super::method::{Function, Method};
 
@@ -13,10 +13,10 @@ type TypeErasedMethod<R> =
     Arc<dyn Fn(&Instance, Vec<PolarValue>, &Host) -> super::Result<R> + Send + Sync>;
 
 #[derive(Clone)]
-pub struct Constructor(TypeErasedFunction<Instance>, Vec<ParamType>);
+pub struct Constructor(TypeErasedFunction<Instance>, Vec<&'static str>);
 
 impl Constructor {
-    pub fn new<Args, F>(f: F, param_types: Vec<ParamType>) -> Self
+    pub fn new<Args, F>(f: F, param_types: Vec<&'static str>) -> Self
     where
         Args: FromPolarList,
         F: Function<Args>,
@@ -32,7 +32,7 @@ impl Constructor {
         self.0(args)
     }
 
-    pub fn param_types(&self) -> &Vec<ParamType> {
+    pub fn get_param_types(&self) -> &Vec<&'static str> {
         &self.1
     }
 }
@@ -64,10 +64,10 @@ impl AttributeGetter {
 }
 
 #[derive(Clone)]
-pub struct InstanceMethod(TypeErasedMethod<PolarValue>, Vec<ParamType>, Option<String>);
+pub struct InstanceMethod(TypeErasedMethod<PolarValue>, Vec<&'static str>, Option<&'static str>);
 
 impl InstanceMethod {
-    pub fn new<T, F, Args>(f: F, param_types: Vec<ParamType>, path: Option<String>) -> Self
+    pub fn new<T, F, Args>(f: F, param_types: Vec<&'static str>, path: Option<&'static str>) -> Self
     where
         Args: FromPolarList,
         F: Method<T, Args>,
@@ -150,11 +150,11 @@ impl InstanceMethod {
         )
     }
 
-    pub fn param_types(&self) -> &Vec<ParamType> {
+    pub fn param_types(&self) -> &Vec<&'static str> {
         &self.1
     }
 
-    pub fn path(&self) -> &Option<String> {
+    pub fn path(&self) -> &Option<&'static str> {
         &self.2
     }
 }

--- a/core-lib/src/command/oso/from_polar.rs
+++ b/core-lib/src/command/oso/from_polar.rs
@@ -45,7 +45,7 @@ macro_rules! polar_to_int {
                 if let PolarValue::Integer(i) = val {
                     <$i>::try_from(i).map_err(|_| super::OsoError::FromPolar)
                 } else {
-                    Err(TypeError::expected("Integer").user())
+                    Err(TypeError::expected("int").user())
                 }
             }
         }
@@ -68,7 +68,7 @@ where
         if let PolarValue::Instance(instance) = val {
             Ok(instance.downcast::<T>(None).map_err(|e| e.user())?.clone())
         } else {
-            Err(TypeError::expected("Instance").user())
+            Err(TypeError::expected("instance").user())
         }
     }
 }
@@ -78,7 +78,7 @@ impl FromPolar for f64 {
         if let PolarValue::Float(f) = val {
             Ok(f)
         } else {
-            Err(TypeError::expected("Float").user())
+            Err(TypeError::expected("float").user())
         }
     }
 }
@@ -88,7 +88,7 @@ impl FromPolar for String {
         if let PolarValue::String(s) = val {
             Ok(s)
         } else {
-            Err(TypeError::expected("String").user())
+            Err(TypeError::expected("string").user())
         }
     }
 }
@@ -98,7 +98,7 @@ impl FromPolar for bool {
         if let PolarValue::Boolean(b) = val {
             Ok(b)
         } else {
-            Err(TypeError::expected("Boolean").user())
+            Err(TypeError::expected("bool").user())
         }
     }
 }
@@ -113,7 +113,7 @@ impl<T: FromPolar> FromPolar for HashMap<String, T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("Map").user())
+            Err(TypeError::expected("dict").user())
         }
     }
 }
@@ -128,7 +128,7 @@ impl<T: FromPolar> FromPolar for BTreeMap<String, T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("Map").user())
+            Err(TypeError::expected("dict").user())
         }
     }
 }
@@ -142,7 +142,7 @@ impl<T: FromPolar> FromPolar for Vec<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }
@@ -156,7 +156,7 @@ impl<T: FromPolar> FromPolar for LinkedList<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }
@@ -170,7 +170,7 @@ impl<T: FromPolar> FromPolar for VecDeque<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }
@@ -184,7 +184,7 @@ impl<T: Eq + Hash + FromPolar> FromPolar for HashSet<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }
@@ -198,7 +198,7 @@ impl<T: Eq + Ord + FromPolar> FromPolar for BTreeSet<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }
@@ -212,7 +212,7 @@ impl<T: Ord + FromPolar> FromPolar for BinaryHeap<T> {
             }
             Ok(result)
         } else {
-            Err(TypeError::expected("List").user())
+            Err(TypeError::expected("list").user())
         }
     }
 }

--- a/core-lib/src/command/oso/mod.rs
+++ b/core-lib/src/command/oso/mod.rs
@@ -33,7 +33,7 @@ pub use errors::{InvalidCallError, OsoError, Result, TypeError};
 pub use class::{Class, ClassBuilder, Instance};
 pub use from_polar::{FromPolar, FromPolarList};
 pub use to_polar::{ToPolar, ToPolarList, PolarIterator, ToPolarResult};
-pub use value::{PolarValue, ParamType};
+pub use value::{PolarValue};
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -171,18 +171,17 @@ impl Host {
         }
     }
 
-    pub fn isa(&self, value: PolarValue, class_tag: &str) -> Result<bool> {
+    pub fn isa(&self, value: &PolarValue, class_tag: &str) -> Result<bool> {
         let res = match value {
             PolarValue::Instance(instance) => {
                 let class = self.get_class(class_tag)?;
                 instance.instance_of(class)
             }
-            PolarValue::Boolean(_) => class_tag == "Boolean",
-            PolarValue::Map(_) => class_tag == "Dictionary",
-            PolarValue::List(_) => class_tag == "List",
-            PolarValue::Integer(_) => class_tag == "Integer",
-            PolarValue::Float(_) => class_tag == "Float",
-            PolarValue::String(_) => class_tag == "String"
+            PolarValue::Boolean(_) => class_tag == "bool",
+            PolarValue::Integer(_) => class_tag == "int",
+            PolarValue::Float(_) => class_tag == "float",
+            PolarValue::String(_) => class_tag == "string",
+            _ => false
         };
         Ok(res)
     }

--- a/core-lib/src/command/oso/value.rs
+++ b/core-lib/src/command/oso/value.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::HashMap;
-use std::fmt::{Display, Formatter};
 
 use super::Instance;
 
@@ -43,26 +42,5 @@ impl PolarValue {
         T: Send + Sync + 'static,
     {
         Self::Instance(Instance::new(instance))
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ParamType {
-    Integer,
-    Float,
-    String,
-    Boolean,
-    Instance
-}
-
-impl Display for ParamType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParamType::Integer => f.write_str("Integer"),
-            ParamType::Float => f.write_str("Float"),
-            ParamType::String => f.write_str("String"),
-            ParamType::Boolean => f.write_str("Boolean"),
-            ParamType::Instance => f.write_str("Instance")
-        }
     }
 }


### PR DESCRIPTION
Methods can now be called on objects stored in the command path.

    let result = registry.parsed_invoke_method_value(
        /foo/add_one, ., vec[A42]).unwrap();
    assert_eq!(43, result);