### PR TITLE
Command Parser

### DIFF
--- a/core-lib/src/command/lexer.rs
+++ b/core-lib/src/command/lexer.rs
@@ -3,73 +3,68 @@ use std::fmt;
 use std::fmt::Formatter;
 use std::str::Chars;
 
-#[derive(Debug)]
-#[derive(PartialEq)]
-pub(crate) enum LexerErrorType {
-    UnterminatedQuote,
-    InvalidEscapedCharacter,
-    UnknownVariable,
-    InvalidVariableFormat
-}
+use thiserror::Error;
 
-#[derive(Debug)]
-#[derive(PartialEq)]
-pub(crate) struct LexerError {
-    pub(crate) line_num: i32,
-    pub(crate) command_num: i32,
-    pub(crate) error: LexerErrorType
-}
-
-impl LexerError {
-    pub(crate) fn new(line_num: i32, command_num: i32, error: LexerErrorType) -> LexerError {
-        LexerError { line_num, command_num, error }
+/// Errors thrown lexing commands from the command file.
+#[derive(Debug, PartialEq, Error)]
+pub enum LexerError {
+    #[error("{line}: the command contains an unterminated quote")]
+    UnterminatedQuote {
+        line: usize
+    },
+    #[error("{line}:{column}: the escaped character is not in quotes")]
+    EscapedCharacterNotInQuotes {
+        line: usize,
+        column: usize,
+    },
+    #[error("{line}:{column}: '{character}' is an invalid escaped character")]
+    InvalidEscapedCharacterFormat {
+        line: usize,
+        column: usize,
+        character: String
+    },
+    #[error("{line}:{column}: {variable} is an unknown variable")]
+    UnknownVariable {
+        line: usize,
+        column: usize,
+        variable: String
+    },
+    #[error("{line}:{column}: the variable is in an unknown format")]
+    InvalidVariableFormat {
+        line: usize,
+        column: usize
     }
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Command {
-    pub(crate) line_num: i32,
-    pub(crate) command_num: i32,
+    pub(crate) line: usize,
     pub(crate) tokens: Vec<String>,
-    pub(crate) text: String
-}
-
-impl Command {
-    pub(crate) fn new(line_num: i32, command_num: i32, tokens: Vec<String>, text: String)
-                      -> Command {
-        Command { line_num, command_num, tokens, text }
-    }
 }
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: ", self.line_num)?;
+        write!(f, "{}: ", self.line)?;
         for token in self.tokens.iter() {
             write!(f, " \"{}\"", token)?;
         }
-        write!(f, " [{}]", self.command_num)
+        write!(f, "")
     }
 }
 
 pub(crate) struct Lexer<'a> {
     commands: Chars<'a>,
     context: &'a dyn LexerContext,
-    line_num: i32,
-    command_num: i32
+    line: usize,
+    column: usize
 }
 
 impl<'a> Lexer<'a> {
     pub(crate) fn new(commands: &'a str, context: &'a dyn LexerContext) -> Lexer<'a> {
-        Lexer {
-            commands: commands.chars(),
-            context,
-            line_num: 1,
-            command_num: 0
-        }
+        Lexer { commands: commands.chars(), context, line: 0, column: 0 }
     }
 
-    fn expand(&mut self, token: &String, in_quotes: bool) -> Result<String, LexerErrorType> {
+    fn expand(&self, token: &str, in_quotes: bool) -> Result<String, LexerError> {
         let mut first_char = true;
         let mut in_replace = false;
         let mut in_replace_first_char = false;
@@ -86,17 +81,17 @@ impl<'a> Lexer<'a> {
                     if in_replace {
                         if in_replace_first_char || has_curly_brackets {
                             // $ at the end of a line or missing the closing curly bracket ${foo}
-                            return Err(LexerErrorType::InvalidVariableFormat);
+                            return Err(self.invalid_var_format());
                         } else if variable.is_empty() {
                             // end of argument
                             match self.context.get_argument(argument) {
-                                None => return Err(LexerErrorType::UnknownVariable),
+                                None => return Err(self.unknown_arg(argument)),
                                 Some(arg) => expanded.push_str(arg)
                             }
                         } else {
                             // end of variable
                             match self.context.get_value(&variable) {
-                                None => return Err(LexerErrorType::UnknownVariable),
+                                None => return Err(self.unknown_var(&variable)),
                                 Some(arg) => expanded.push_str(arg)
                             }
                         }
@@ -111,7 +106,7 @@ impl<'a> Lexer<'a> {
                             // first char decides whether we are in an argument or variable
                             if c == '$' {
                                 if has_curly_brackets {
-                                    return Err(LexerErrorType::InvalidVariableFormat);
+                                    return Err(self.invalid_var_format());
                                 }
 
                                 // double dollar sign is just a dollar sign character
@@ -130,7 +125,7 @@ impl<'a> Lexer<'a> {
                                 // skip over curly bracket, ${foo}
                                 has_curly_brackets = true;
                             } else {
-                                return Err(LexerErrorType::InvalidVariableFormat);
+                                return Err(self.invalid_var_format());
                             }
                         } else {
                             // second+ char
@@ -143,11 +138,11 @@ impl<'a> Lexer<'a> {
                                     argument *= 10;
                                     argument += usize::try_from(c.to_digit(10).unwrap()).unwrap();
                                 } else if !in_quotes && (c.is_alphabetic() || c == '$') {
-                                    return Err(LexerErrorType::InvalidVariableFormat);
+                                    return Err(self.invalid_var_format());
                                 } else {
                                     // finished reading the argument, get the value
                                     match self.context.get_argument(argument) {
-                                        None => return Err(LexerErrorType::UnknownVariable),
+                                        None => return Err(self.unknown_arg(argument)),
                                         Some(arg) => expanded.push_str(arg)
                                     }
                                     argument = 0;
@@ -159,11 +154,11 @@ impl<'a> Lexer<'a> {
                                     // add to variable name
                                     variable.push(c);
                                 } else if !in_quotes && c == '$' {
-                                    return Err(LexerErrorType::InvalidVariableFormat);
+                                    return Err(self.escaped_no_quotes());
                                 } else {
                                     // finished reading the variable, get the value out
                                     match self.context.get_value(&variable) {
-                                        None => return Err(LexerErrorType::UnknownVariable),
+                                        None => return Err(self.unknown_var(&variable)),
                                         Some(arg) => expanded.push_str(arg)
                                     }
                                     variable.clear();
@@ -174,7 +169,7 @@ impl<'a> Lexer<'a> {
                             if did_expansion {
                                 if has_curly_brackets {
                                     if c != '}' {
-                                        return Err(LexerErrorType::InvalidVariableFormat);
+                                        return Err(self.invalid_var_format());
                                     }
                                     in_replace = false;
                                     has_curly_brackets = false;
@@ -191,7 +186,7 @@ impl<'a> Lexer<'a> {
                             in_replace = true;
                             in_replace_first_char = true;
                         } else {
-                            return Err(LexerErrorType::InvalidVariableFormat);
+                            return Err(self.escaped_no_quotes());
                         }
                     } else {
                         // regular character
@@ -201,6 +196,56 @@ impl<'a> Lexer<'a> {
                     first_char = false;
                 }
             }
+        }
+    }
+
+    fn unterminated_quote(&self) -> LexerError {
+        LexerError::UnterminatedQuote {
+            line: self.line
+        }
+    }
+
+    fn invalid_escaped(&self, character: char) -> LexerError {
+        let mut str = "\\".to_owned();
+        str.push(character);
+        LexerError::InvalidEscapedCharacterFormat {
+            line: self.line,
+            column: self.column,
+            character: str,
+        }
+    }
+
+    fn unknown_var(&self, variable: &str) -> LexerError {
+        let mut var = "$".to_owned();
+        var.push_str(variable);
+        LexerError::UnknownVariable {
+            line: self.line,
+            column: self.column,
+            variable: var
+        }
+    }
+
+    fn unknown_arg(&self, argument: usize) -> LexerError {
+        let mut var = "$".to_owned();
+        var.push_str(&argument.to_string());
+        LexerError::UnknownVariable {
+            line: self.line,
+            column: self.column,
+            variable: var
+        }
+    }
+
+    fn invalid_var_format(&self) -> LexerError {
+        LexerError::InvalidVariableFormat {
+            line: self.line,
+            column: self.column
+        }
+    }
+
+    fn escaped_no_quotes(&self) -> LexerError {
+        LexerError::EscapedCharacterNotInQuotes {
+            line: self.line,
+            column: self.column
         }
     }
 }
@@ -214,79 +259,70 @@ impl<'a> Iterator for Lexer<'a> {
         let mut in_backslash = false;
         let mut token = String::new();
         let mut tokens: Vec<String> = Vec::new();
-        let mut lines = 0;
-        let mut text = String::new();
-
-        self.command_num += 1;
+        let mut token_col = 0;
+        self.column = 1;
+        self.line += 1;
 
         loop {
             match self.commands.next() {
                 None => {
                     // end of file
                     if in_quotes {
-                        return Some(Err(LexerError::new(
-                            self.line_num, self.command_num,
-                            LexerErrorType::UnterminatedQuote)));
+                        return Some(Err(self.unterminated_quote()));
                     }
 
                     // add the last token
                     if !token.is_empty() {
-                        match self.expand(&mut token, in_quotes) {
-                            Ok(expanded) => tokens.push(expanded),
-                            Err(e) => return Some(Err(
-                                LexerError::new(self.line_num, self.command_num, e)))
-                        }
+                        tokens.push(match self.expand(&token, in_quotes) {
+                            Ok(v) => v,
+                            Err(e) => return Some(Err(e))
+                        });
                         token.clear();
+                        self.column += token_col;
                     }
 
                     if tokens.len() > 0 {
-                        let command = Command::new(
-                            self.line_num, self.command_num, tokens, text);
-                        self.line_num += lines;
+                        let command = Command { line: self.line, tokens };
                         return Some(Ok(command));
                     } else {
                         return None;
                     }
                 }
                 Some(c) => {
-                    text.push(c);
+                    token_col += 1;
 
                     if c == '\n' {
                         // end of line
                         if in_quotes {
-                            return Some(Err(LexerError::new(
-                                self.line_num, self.command_num,
-                                LexerErrorType::UnterminatedQuote)));
+                            return Some(Err(self.unterminated_quote()));
                         }
 
                         // add the last token
                         if !token.is_empty() {
-                            match self.expand(&token, in_quotes) {
-                                Ok(expanded) => tokens.push(expanded),
-                                Err(e) => return Some(Err(
-                                    LexerError::new(self.line_num, self.command_num, e)))
-                            }
+                            tokens.push(match self.expand(&token, in_quotes) {
+                                Ok(v) => v,
+                                Err(e) => return Some(Err(e))
+                            });
                             token.clear();
+                            self.column += token_col;
+                            token_col = 0;
                         }
-                        lines += 1;
 
                         // continue to the next line if the last character is a backslash
                         if !in_backslash && tokens.len() > 0 {
-                            let command = Command::new(
-                                self.line_num, self.command_num, tokens, text);
-                            self.line_num += lines;
+                            let command = Command { line: self.line, tokens };
                             return Some(Ok(command));
                         }
 
+                        self.line += 1;
+                        self.column = 0;
                         in_quotes = false;
                         in_comment = false;
                         in_backslash = false;
                     } else if !in_comment {
                         if in_backslash {
                             if !in_quotes {
-                                return Some(Err(LexerError::new(
-                                    self.line_num, self.command_num,
-                                    LexerErrorType::InvalidEscapedCharacter)));
+                                return Some(Err(self.invalid_escaped(c)));
                             }
 
                             // special characters that are escaped
@@ -297,9 +333,7 @@ impl<'a> Iterator for Lexer<'a> {
                             } else if c == '"' {
                                 token.push('"');
                             } else {
-                                return Some(Err(LexerError::new(
-                                    self.line_num, self.command_num,
-                                    LexerErrorType::InvalidEscapedCharacter)));
+                                return Some(Err(self.invalid_escaped(c)));
                             }
 
                             in_backslash = false;
@@ -310,24 +344,26 @@ impl<'a> Iterator for Lexer<'a> {
                             if in_quotes {
                                 // end quotes
                                 // include zero length tokens
-                                match self.expand(&token, in_quotes) {
-                                    Ok(expanded) => tokens.push(expanded),
-                                    Err(e) => return Some(Err(
-                                        LexerError::new(self.line_num, self.command_num, e)))
-                                }
+                                tokens.push(match self.expand(&token, in_quotes) {
+                                    Ok(v) => v,
+                                    Err(e) => return Some(Err(e))
+                                });
                                 token.clear();
+                                self.column += token_col;
+                                token_col = 0;
                             }
                             in_quotes = !in_quotes
                         } else if c == '#' && !in_quotes {
                             // start of comment
                             // add the last token
                             if !token.is_empty() {
-                                match self.expand(&token, in_quotes) {
-                                    Ok(expanded) => tokens.push(expanded),
-                                    Err(e) => return Some(Err(
-                                        LexerError::new(self.line_num, self.command_num, e)))
-                                }
+                                tokens.push(match self.expand(&token, in_quotes) {
+                                    Ok(v) => v,
+                                    Err(e) => return Some(Err(e))
+                                });
                                 token.clear();
+                                self.column += token_col;
+                                token_col = 0;
                             }
 
                             in_comment = true;
@@ -337,12 +373,13 @@ impl<'a> Iterator for Lexer<'a> {
                                 token.push(c);
                             } else if !token.is_empty() {
                                 // end the current token
-                                match self.expand(&token, in_quotes) {
-                                    Ok(expanded) => tokens.push(expanded),
-                                    Err(e) => return Some(Err(
-                                        LexerError::new(self.line_num, self.command_num, e)))
-                                }
+                                tokens.push(match self.expand(&token, in_quotes) {
+                                    Ok(v) => v,
+                                    Err(e) => return Some(Err(e))
+                                });
                                 token.clear();
+                                self.column += token_col;
+                                token_col = 0;
                             }
                             // otherwise, ignore whitespace
                         } else {
@@ -358,8 +395,10 @@ impl<'a> Iterator for Lexer<'a> {
 
 pub trait LexerContext {
     fn get_argument(&self, position: usize) -> Option<&String>;
-    fn get_value(&self, key: &str) -> Option<&String>;
     fn add_argument(&mut self, value: &str);
+    fn clear_arguments(&mut self);
+
+    fn get_value(&self, key: &str) -> Option<&String>;
     fn set_value(&mut self, key: &str, value: &str, force: bool);
 }
 
@@ -368,12 +407,16 @@ impl LexerContext for SimpleContext {
         self.arguments.get(position)
     }
 
-    fn get_value(&self, key: &str) -> Option<&String> {
-        self.variables.get(key)
-    }
-
     fn add_argument(&mut self, value: &str) {
         self.arguments.push(value.to_string());
+    }
+
+    fn clear_arguments(&mut self) {
+        self.arguments.clear();
+    }
+
+    fn get_value(&self, key: &str) -> Option<&String> {
+        self.variables.get(key)
     }
 
     fn set_value(&mut self, key: &str, value: &str, force: bool) {
@@ -399,7 +442,7 @@ impl SimpleContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::command::lexer::{Lexer, LexerContext, LexerError, LexerErrorType, SimpleContext};
+    use crate::command::lexer::{Lexer, LexerContext, LexerError, SimpleContext};
 
     #[test]
     fn print_debug_command() {
@@ -437,9 +480,9 @@ mod tests {
     fn quotes_not_terminated_at_end_of_file_throws_error() {
         let text = "foo \"bar me";
 
-        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap();
+        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::UnterminatedQuote)));
+        assert_eq!(result, LexerError::UnterminatedQuote { line: 1 });
     }
 
     #[test]
@@ -447,18 +490,20 @@ mod tests {
         let text = "foo \"bar me
         hey there";
 
-        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap();
+        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::UnterminatedQuote)));
+        assert_eq!(result, LexerError::UnterminatedQuote { line: 1 });
     }
 
     #[test]
     fn invalid_escaped_character_throws_error() {
         let text = "foo \"b\\^br\" me";
 
-        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap();
+        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::InvalidEscapedCharacter)));
+        assert_eq!(result, LexerError::InvalidEscapedCharacterFormat {
+            line: 1, column: 5, character: "\\^".to_owned()
+        });
     }
 
     #[test]
@@ -559,9 +604,9 @@ mod tests {
     fn backslash_not_in_quotes_is_error() {
         let text = "back\\\"slash";
 
-        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap();
+        let result = Lexer::new(text, &SimpleContext::new()).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::InvalidEscapedCharacter)));
+        assert_eq!(result, LexerError::InvalidEscapedCharacterFormat { line: 1, column: 1, character: "\\\"".to_owned() });
     }
 
     #[test]
@@ -611,9 +656,9 @@ mod tests {
         let mut context = SimpleContext::new();
         context.add_argument(" left his home");
 
-        let commands = Lexer::new(text, &context).next().unwrap();
+        let commands = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(commands, Err(LexerError::new(1, 1, LexerErrorType::InvalidVariableFormat)));
+        assert_eq!(commands, LexerError::EscapedCharacterNotInQuotes { line: 1, column: 1 });
     }
 
     #[test]
@@ -623,9 +668,9 @@ mod tests {
         context.add_argument("Jojo");
         context.add_argument(" left his home");
 
-        let commands = Lexer::new(text, &context).next().unwrap();
+        let commands = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(commands, Err(LexerError::new(1, 1, LexerErrorType::InvalidVariableFormat)));
+        assert_eq!(commands, LexerError::InvalidVariableFormat { line: 1, column: 1 });
     }
 
     #[test]
@@ -659,9 +704,11 @@ mod tests {
         let mut context = SimpleContext::new();
         context.add_argument(" left his home");
 
-        let result = Lexer::new(text, &context).next().unwrap();
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::UnknownVariable)));
+        assert_eq!(result, LexerError::UnknownVariable {
+            line: 1, column: 1, variable: "$1".to_owned()
+        });
     }
 
     #[test]
@@ -709,9 +756,9 @@ mod tests {
         let mut context = SimpleContext::new();
         context.set_value("foo", " left his home", true);
 
-        let result = Lexer::new(text, &context).next().unwrap();
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::InvalidVariableFormat)));
+        assert_eq!(result, LexerError::EscapedCharacterNotInQuotes { line: 1, column: 1 });
     }
 
     #[test]
@@ -732,9 +779,11 @@ mod tests {
         let mut context = SimpleContext::new();
         context.add_argument(" left his home");
 
-        let result = Lexer::new(text, &context).next().unwrap();
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::UnknownVariable)));
+        assert_eq!(result, LexerError::UnknownVariable {
+            line: 1, column: 1, variable: "$1".to_owned()
+        });
     }
 
     #[test]
@@ -759,9 +808,9 @@ mod tests {
         context.set_value("foo", "Jojo left", true);
         context.set_value("bar", " his home", true);
 
-        let result = Lexer::new(text, &context).next().unwrap();
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::InvalidVariableFormat)));
+        assert_eq!(result, LexerError::EscapedCharacterNotInQuotes { line: 1, column: 1 });
     }
 
     #[test]
@@ -795,8 +844,19 @@ mod tests {
         let mut context = SimpleContext::new();
         context.set_value("foo", "Jojo left ", true);
 
-        let result = Lexer::new(text, &context).next().unwrap();
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
 
-        assert_eq!(result, Err(LexerError::new(1, 1, LexerErrorType::InvalidVariableFormat)));
+        assert_eq!(result, LexerError::InvalidVariableFormat { line: 1, column: 1 });
+    }
+
+    #[test]
+    fn invalid_character_in_first_part_of_variable_is_error() {
+        let text = "$@foo";
+        let mut context = SimpleContext::new();
+        context.set_value("f@oo", "Jojo left ", true);
+
+        let result = Lexer::new(text, &context).next().unwrap().err().unwrap();
+
+        assert_eq!(result, LexerError::InvalidVariableFormat { line: 1, column: 1 });
     }
 }

--- a/core-lib/src/command/lexer.rs
+++ b/core-lib/src/command/lexer.rs
@@ -36,10 +36,10 @@ pub enum LexerError {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub(crate) struct Command {
-    pub(crate) line: usize,
-    pub(crate) tokens: Vec<String>,
+#[derive(Debug, PartialEq, Clone)]
+pub struct Command {
+    pub line: usize,
+    pub tokens: Vec<String>,
 }
 
 impl fmt::Display for Command {
@@ -399,7 +399,7 @@ pub trait LexerContext {
     fn clear_arguments(&mut self);
 
     fn get_value(&self, key: &str) -> Option<&String>;
-    fn set_value(&mut self, key: &str, value: &str, force: bool);
+    fn set_value(&mut self, key: &str, value: &str, overwrite: bool);
 }
 
 impl LexerContext for SimpleContext {
@@ -419,8 +419,8 @@ impl LexerContext for SimpleContext {
         self.variables.get(key)
     }
 
-    fn set_value(&mut self, key: &str, value: &str, force: bool) {
-        if force || !self.variables.contains_key(key) {
+    fn set_value(&mut self, key: &str, value: &str, overwrite: bool) {
+        if overwrite || !self.variables.contains_key(key) {
             self.variables.insert(key.to_string(), value.to_string());
         }
     }

--- a/core-lib/src/command/lexer.rs
+++ b/core-lib/src/command/lexer.rs
@@ -37,12 +37,12 @@ pub enum LexerError {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct Command {
+pub struct TokenGroup {
     pub line: usize,
     pub tokens: Vec<String>,
 }
 
-impl fmt::Display for Command {
+impl fmt::Display for TokenGroup {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}: ", self.line)?;
         for token in self.tokens.iter() {
@@ -251,7 +251,7 @@ impl<'a> Lexer<'a> {
 }
 
 impl<'a> Iterator for Lexer<'a> {
-    type Item = Result<Command, LexerError>;
+    type Item = Result<TokenGroup, LexerError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut in_quotes = false;
@@ -282,8 +282,8 @@ impl<'a> Iterator for Lexer<'a> {
                     }
 
                     if tokens.len() > 0 {
-                        let command = Command { line: self.line, tokens };
-                        return Some(Ok(command));
+                        let group = TokenGroup { line: self.line, tokens };
+                        return Some(Ok(group));
                     } else {
                         return None;
                     }
@@ -310,8 +310,8 @@ impl<'a> Iterator for Lexer<'a> {
 
                         // continue to the next line if the last character is a backslash
                         if !in_backslash && tokens.len() > 0 {
-                            let command = Command { line: self.line, tokens };
-                            return Some(Ok(command));
+                            let group = TokenGroup { line: self.line, tokens };
+                            return Some(Ok(group));
                         }
 
                         self.line += 1;

--- a/core-lib/src/command/parser.rs
+++ b/core-lib/src/command/parser.rs
@@ -1,64 +1,153 @@
-use crate::command::lexer::{Lexer, LexerContext, LexerError, SimpleContext};
+use std::fmt::{Debug, Display, Formatter};
+use crate::command::lexer::{Command, Lexer, LexerContext, LexerError};
 
-pub trait ExecutableCommand {
+pub trait ExecutableCommandSpec {
+    fn validate(&self, command: &Command) -> Result<bool, ParserError>;
+    fn build(&self, command: &mut Command) -> Box<dyn ExecutableCommand>;
+}
+
+pub trait ExecutableCommand: Debug {
     fn execute(&self, context: &mut dyn LexerContext);
 }
 
+#[derive(Default)]
+pub struct AssignmentCommandSpec {}
+
+#[derive(Debug, PartialEq)]
 pub struct AssignmentCommand {
-    words: Vec<String>
+    variable: String,
+    value: String
 }
 
-impl AssignmentCommand {
-    fn is_command(words: &Vec<String>) -> bool {
-        return words.len() == 3 && (words[1] == "=" || words[1] == ":=");
+#[derive(Default)]
+pub struct DefaultAssignmentCommandSpec {}
+
+#[derive(Debug, PartialEq)]
+pub struct DefaultAssignmentCommand {
+    variable: String,
+    value: String
+}
+
+impl ExecutableCommandSpec for AssignmentCommandSpec {
+    fn validate(&self, command: &Command) -> Result<bool, ParserError> {
+        validate_assigment(command, "=")
     }
 
-    pub fn new(words: Vec<String>) -> AssignmentCommand {
-        AssignmentCommand {
-            words
-        }
+    fn build(&self, command: &mut Command) -> Box<dyn ExecutableCommand> {
+        Box::new(AssignmentCommand {
+            value: command.tokens.remove(2),
+            variable: command.tokens.remove(0),
+        })
     }
 }
 
 impl ExecutableCommand for AssignmentCommand {
     fn execute(&self, context: &mut dyn LexerContext) {
-        context.set_value(&self.words[0], &self.words[2], self.words[1] == "=");
+        context.set_value(&self.variable, &self.value, true);
+    }
+}
+
+impl Display for AssignmentCommand {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.variable)?;
+        f.write_str(" = ")?;
+        f.write_str(&self.value)
+    }
+}
+
+impl ExecutableCommandSpec for DefaultAssignmentCommandSpec {
+    fn validate(&self, command: &Command) -> Result<bool, ParserError> {
+        validate_assigment(command, ":=")
+    }
+
+    fn build(&self, command: &mut Command) -> Box<dyn ExecutableCommand> {
+        Box::new(DefaultAssignmentCommand {
+            value: command.tokens.remove(2),
+            variable: command.tokens.remove(0),
+        })
+    }
+}
+
+impl ExecutableCommand for DefaultAssignmentCommand {
+    fn execute(&self, context: &mut dyn LexerContext) {
+        context.set_value(&self.variable, &self.value, false);
+    }
+}
+
+impl Display for DefaultAssignmentCommand {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.variable)?;
+        f.write_str(" := ")?;
+        f.write_str(&self.value)
+    }
+}
+
+fn validate_variable(variable: &str) -> bool {
+    let mut first = true;
+
+    for c in variable.chars() {
+        if first && !c.is_alphabetic() && c != '_' {
+            return false;
+        } else if !c.is_alphanumeric() && c != '_' {
+            return false;
+        }
+        first = false;
+    }
+
+    return true;
+}
+
+fn validate_assigment(command: &Command, sign: &'static str)
+                      -> Result<bool, ParserError> {
+    let tokens = &command.tokens;
+    if tokens.len() == 3 && tokens[1] == sign {
+        if validate_variable(&tokens[0]) {
+            Ok(true)
+        } else {
+            Err(ParserError::InvalidVariableName {
+                command: command.to_owned(),
+                variable: tokens[0].to_owned(),
+            })
+        }
+    } else {
+        Ok(false)
     }
 }
 
 #[derive(Debug, PartialEq)]
 pub enum ParserError {
-    LexerError(LexerError)
+    LexerError(LexerError),
+    InvalidVariableName {
+        command: Command,
+        variable: String
+    },
+    InvalidCommand(Command)
 }
 
 pub struct Parser<'a> {
     file: &'a str,
     context: &'a dyn LexerContext,
-    lexer: Lexer<'a>
+    lexer: Lexer<'a>,
+    command_specs: Vec<Box<dyn ExecutableCommandSpec>>,
+    error: bool
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(file: &'a str, context: &'a dyn LexerContext) -> Parser {
-        Parser {
+    pub fn new(file: &'a str, context: &'a dyn LexerContext) -> Parser<'a> {
+        let mut parser = Parser {
             file,
             context,
-            lexer: Lexer::new()
-        }
+            lexer: Lexer::new(file, context),
+            command_specs: Vec::new(),
+            error: false
+        };
+        parser.add_command(Box::new(AssignmentCommandSpec::default()));
+        parser.add_command(Box::new(DefaultAssignmentCommandSpec::default()));
+        parser
     }
 
-    fn validate_variable(&self, variable: &str) -> bool {
-        let mut first = true;
-
-        for c in variable.chars() {
-            if first && !c.is_alphabetic() {
-                return false;
-            } else if !c.is_alphanumeric() {
-                return false;
-            }
-            first = false;
-        }
-
-        return true;
+    pub fn add_command(&mut self, spec: Box<dyn ExecutableCommandSpec>) {
+        self.command_specs.push(spec);
     }
 }
 
@@ -66,51 +155,255 @@ impl<'a> Iterator for Parser<'a> {
     type Item = Result<Box<dyn ExecutableCommand>, ParserError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let lexer = Lexer::new(self.file, self.context);
-        let mut statement_number = 1;
-
-        for statement_result in lexer {
-            match statement_result {
-                Ok(statement) => {
-                    let words = statement.tokens;
-
-                    if AssignmentCommand::is_command(&words) {
-                        if !self.validate_variable(&words[0]) {
-                            return Some(Err(ParserError::new(
-                                ParserError::LexerUnknownVariable,
-                                statement.line,
-                                statement_number,
-                                self.file
-                            )));
-                        }
-
-                        return Some(Ok(Box::new(AssignmentCommand::new(words))));
-                    }
-
-                    statement_number += 1;
-                }
-                Err(statement_error) => {
-                    let command_error_type = match statement_error.reason {
-                        LexerError::UnterminatedQuote =>
-                            ParserError::LexerUnterminatedQuote,
-                        LexerError::InvalidEscapedCharacterFormat =>
-                            ParserError::LexerInvalidEscapedCharacter,
-                        LexerError::UnknownVariable =>
-                            ParserError::LexerUnknownVariable,
-                        LexerError::InvalidVariableFormat =>
-                            ParserError::LexerInvalidVariableFormat
-                    };
-
-                    return Some(Err(ParserError::new(
-                        command_error_type,
-                        statement_error.line_num,
-                        statement_number,
-                        self.file
-                    )));
-                }
-            }
+        if self.error {
+            return None
         }
 
-        None
+        match self.lexer.next() {
+            Some(result) => {
+                match result {
+                    Ok(mut command) => {
+                        for spec in &self.command_specs {
+                            match spec.validate(&command) {
+                                Ok(result) => if result {
+                                    return Some(Ok(spec.build(&mut command)));
+                                }
+                                Err(e) => {
+                                    self.error = true;
+                                    return Some(Err(e))
+                                }
+                            }
+                        }
+
+                        self.error = true;
+                        return Some(Err(ParserError::InvalidCommand(command)))
+                    }
+                    Err(e) => {
+                        self.error = true;
+                        Some(Err(ParserError::LexerError(e)))
+                    }
+                }
+            },
+            None => None
+        }
+    }
+}
+
+#[cfg(test)]
+mod assignment_tests {
+    use crate::command::lexer::Command;
+    use crate::command::parser::{AssignmentCommandSpec, ExecutableCommandSpec, ParserError};
+
+    #[test]
+    fn validate_valid_assignment_command_returns_true() {
+        let spec = AssignmentCommandSpec::default();
+
+        let result = spec.validate(&Command {
+            line: 0,
+            tokens: vec!["foo".to_owned(), "=".to_owned(), "bar".to_owned()],
+        }).unwrap();
+
+        assert!(result);
+    }
+
+    #[test]
+    fn validate_invalid_assignment_command_returns_false() {
+        let spec = AssignmentCommandSpec::default();
+
+        let result = spec.validate(&Command {
+            line: 0,
+            tokens: vec!["foo".to_owned(), ":=".to_owned(), "bar".to_owned()],
+        }).unwrap();
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn validate_invalid_variable_name_returns_error() {
+        let spec = AssignmentCommandSpec::default();
+        let command = Command {
+            line: 0,
+            tokens: vec!["12foo".to_owned(), "=".to_owned(), "bar".to_owned()],
+        };
+
+        let result = spec.validate(&command).err().unwrap();
+
+        assert_eq!(ParserError::InvalidVariableName { command, variable: "12foo".to_owned() }, result);
+    }
+}
+
+#[cfg(test)]
+mod default_assignment_tests {
+    use crate::command::lexer::Command;
+    use crate::command::parser::{DefaultAssignmentCommandSpec, ExecutableCommandSpec, ParserError};
+
+    #[test]
+    fn validate_valid_assignment_command_returns_true() {
+        let spec = DefaultAssignmentCommandSpec::default();
+
+        let result = spec.validate(&Command {
+            line: 0,
+            tokens: vec!["foo".to_owned(), ":=".to_owned(), "bar".to_owned()],
+        }).unwrap();
+
+        assert!(result);
+    }
+
+    #[test]
+    fn validate_invalid_assignment_command_returns_false() {
+        let spec = DefaultAssignmentCommandSpec::default();
+
+        let result = spec.validate(&Command {
+            line: 0,
+            tokens: vec!["foo".to_owned(), "=".to_owned(), "bar".to_owned()],
+        }).unwrap();
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn validate_invalid_variable_name_returns_error() {
+        let spec = DefaultAssignmentCommandSpec::default();
+        let command = Command {
+            line: 0,
+            tokens: vec!["12foo".to_owned(), ":=".to_owned(), "bar".to_owned()],
+        };
+
+        let result = spec.validate(&command).err().unwrap();
+
+        assert_eq!(ParserError::InvalidVariableName { command, variable: "12foo".to_owned() }, result);
+    }
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use crate::command::lexer::{Command, SimpleContext, LexerError, LexerContext};
+    use crate::command::parser::{AssignmentCommand, DefaultAssignmentCommand, ExecutableCommand, ExecutableCommandSpec, Parser, ParserError, validate_variable};
+
+    #[test]
+    fn command_iteration() {
+        let context = SimpleContext::new();
+        let mut parser = Parser::new(
+            "foo = bar
+            foo := soo
+            do12 = goo
+            ", &context);
+
+        assert_eq!(format!("{:?}", parser.next().unwrap().unwrap()), format!("{:?}", AssignmentCommand {
+            variable: "foo".to_owned(),
+            value: "bar".to_owned(),
+        }));
+        assert_eq!(format!("{:?}", parser.next().unwrap().unwrap()), format!("{:?}", DefaultAssignmentCommand {
+            variable: "foo".to_owned(),
+            value: "soo".to_owned(),
+        }));
+        assert_eq!(format!("{:?}", parser.next().unwrap().unwrap()), format!("{:?}", AssignmentCommand {
+            variable: "do12".to_owned(),
+            value: "goo".to_owned(),
+        }));
+        assert!(parser.next().is_none());
+    }
+
+    #[test]
+    fn lexer_error_is_passed_through_and_stops_iteration() {
+        let context = SimpleContext::new();
+        let mut parser = Parser::new(
+            "foo = bar
+            fo\"o = soo
+            do12 = goo
+            ", &context);
+        parser.next();
+
+        assert_eq!(ParserError::LexerError(LexerError::UnterminatedQuote { line: 2 }),
+                   parser.next().unwrap().err().unwrap());
+        assert!(parser.next().is_none());
+    }
+
+    #[test]
+    fn unknown_command_throws_error_and_stops_iteration() {
+        let context = SimpleContext::new();
+        let mut parser = Parser::new(
+            "foo = bar
+            foo /= soo
+            do12 = goo
+            ", &context);
+        parser.next();
+
+        assert_eq!(ParserError::InvalidCommand(Command {
+            line: 2,
+            tokens: vec!["foo".to_owned(), "/=".to_owned(), "soo".to_owned()],
+        }), parser.next().unwrap().err().unwrap());
+        assert!(parser.next().is_none());
+    }
+
+    #[test]
+    fn invalid_command_throws_error_and_stops_iteration() {
+        let context = SimpleContext::new();
+        let mut parser = Parser::new(
+            "foo = bar
+            12foo = soo
+            do12 = goo
+            ", &context);
+        parser.next();
+
+        assert_eq!(ParserError::InvalidVariableName {
+            command: Command {
+                line: 2,
+                tokens: vec!["12foo".to_owned(), "=".to_owned(), "soo".to_owned()]
+            },
+            variable: "12foo".to_string(),
+        }, parser.next().unwrap().err().unwrap());
+        assert!(parser.next().is_none());
+    }
+
+    #[derive(Default)]
+    struct RemoveVariableCommandSpec {}
+
+    #[derive(Debug)]
+    struct RemoveVariableCommand {
+        variable: String
+    }
+
+    impl ExecutableCommandSpec for RemoveVariableCommandSpec {
+        fn validate(&self, command: &Command) -> Result<bool, ParserError> {
+            if command.tokens.len() == 1 {
+                let mut chars = command.tokens[0].chars();
+                return match chars.nth(0) {
+                    None => Ok(false),
+                    Some(c) => {
+                        let variable: String = chars.skip(1).collect();
+                        Ok(c == '!' && validate_variable(&variable))
+                    }
+                }
+            }
+            Ok(false)
+        }
+
+        fn build(&self, command: &mut Command) -> Box<dyn ExecutableCommand> {
+            Box::new(RemoveVariableCommand {
+                variable: command.tokens[0].chars().skip(1).collect()
+            })
+        }
+    }
+
+    impl ExecutableCommand for RemoveVariableCommand {
+        fn execute(&self, context: &mut dyn LexerContext) {
+            // do nothing
+        }
+    }
+
+    #[test]
+    fn add_a_new_command() {
+        let context = SimpleContext::new();
+        let mut parser = Parser::new(
+            "foo = bar
+            !remove_me
+            ", &context);
+        parser.add_command(Box::new(RemoveVariableCommandSpec::default()));
+        parser.next();
+
+        assert_eq!(format!("{:?}", parser.next().unwrap().unwrap()), format!("{:?}", RemoveVariableCommand {
+            variable: "remove_me".to_owned()
+        }));
     }
 }

--- a/core-lib/src/command/registry.rs
+++ b/core-lib/src/command/registry.rs
@@ -449,11 +449,11 @@ impl CommandRegistry {
     //
 
     fn parse_params(
-        &self,
-        class_name: &str,
-        method_name: &str,
-        args: &Vec<&str>,
-        param_types: &Vec<&'static str>) -> Result<Vec<PolarValue>, CommandError> {
+            &self,
+            class_name: &str,
+            method_name: &str,
+            args: &Vec<&str>,
+            param_types: &Vec<&'static str>) -> Result<Vec<PolarValue>, CommandError> {
         if args.len() != param_types.len() {
             return Err(CommandError::InvalidNumberOfMethodParameters {
                 class: class_name.to_owned(),


### PR DESCRIPTION
- The command lexer has been updated to return errors in a similar fashion as with the command Registry.

- The command parser uses the lexer's token groups and turns them into commands. For example, three tokens can be used to assign a variable:  "foo" "=" "bar". The command parser identifies, validates, and then provides typed commands to an use of the parser's iterator.

